### PR TITLE
feat: 远程操作支持中文/双拼

### DIFF
--- a/lua/flash-zh/init.lua
+++ b/lua/flash-zh/init.lua
@@ -4,6 +4,7 @@ local flypy = require("flash-zh.flypy")
 local M = {}
 
 function M.jump(opts)
+	opts = opts or {}
 	local mode = M.mix_mode
 	if opts.chinese_only then
 		mode = M.zh_mode
@@ -16,8 +17,26 @@ function M.jump(opts)
 		labeler = function(_, state)
 			require("flash-zh.labeler").new(state):update()
 		end,
-	}, opts or {})
+	}, opts)
 	flash.jump(opts)
+end
+
+function M.remote(opts)
+	opts = opts or {}
+	local mode = M.mix_mode
+	if opts.chinese_only then
+		mode = M.zh_mode
+	end
+	opts = vim.tbl_deep_extend("force", {
+		labels = "asdfghjklqwertyuiopzxcvbnm",
+		search = {
+			mode = mode,
+		},
+		labeler = function(_, state)
+			require("flash-zh.labeler").new(state):update()
+		end,
+	}, opts)
+	flash.remote(opts)
 end
 
 function M.mix_mode(str)


### PR DESCRIPTION
新增 `flash-zh.remote(opts)`，用于 Operator-pending 的 remote 操作（与 `jump()` 使用同一套中文/双拼搜索 mode 与 labeler）。

用法示例：
- `vim.keymap.set('o', 'r', function() require('flash-zh').remote({ chinese_only = false }) end)`
